### PR TITLE
Hide the password to prevent it being accidently displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `Innmind\Url\Authority\UserInformation\Password` inner value is now stored inside a `\SensitiveParameterValue` to prevent a password being accidently displayed in a dump/log.
+
 ## 4.3.0 - 2023-09-16
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~10.2",
-        "vimeo/psalm": "~5.13",
+        "vimeo/psalm": "~5.26",
         "innmind/black-box": "~5.0",
         "innmind/coding-standard": "~2.0"
     },

--- a/src/Authority/UserInformation/Password.php
+++ b/src/Authority/UserInformation/Password.php
@@ -15,11 +15,12 @@ use Innmind\Immutable\Str;
 final class Password
 {
     private const PATTERN = '/^[\pL\pN-]+$/';
-    private string $value;
+    /** @var \SensitiveParameterValue<string> */
+    private \SensitiveParameterValue $value;
 
     private function __construct(string $value)
     {
-        $this->value = $value;
+        $this->value = new \SensitiveParameterValue($value);
     }
 
     /**
@@ -44,12 +45,12 @@ final class Password
 
     public function equals(self $password): bool
     {
-        return $this->value === $password->value;
+        return $this->value->getValue() === $password->value->getValue();
     }
 
     public function format(User $user): string
     {
-        if ($this->value === '') {
+        if ($this->value->getValue() === '') {
             return $user->toString();
         }
 
@@ -57,11 +58,11 @@ final class Password
             throw new PasswordCannotBeSpecifiedWithoutAUser;
         }
 
-        return $user->toString().':'.$this->value;
+        return $user->toString().':'.(string) $this->value->getValue();
     }
 
     public function toString(): string
     {
-        return $this->value;
+        return $this->value->getValue();
     }
 }


### PR DESCRIPTION
## Problem

While testing `innmind/s3` an error occurred and displayed the bucket object along its url. The url contained the bucket password. Since this is a sensitive value it should never be exposed.

## Solution

Wrap the password string inside a `SensitiveParameterValue` so tools like `var_dump`, `symfony/var-dumper` or loggers know the value should not be displayed.

## Note

The password is still exposed when building the `Password` object as a parameter or the exception. The exception is not modified for backward compatibility. The parameters are not flagged as `SensitiveParameter` to help developers debug their code, this is relatively safe as most `Url`s should be built at _compile time_ (where any exception should not be displayed to end users) and the ones built at _runtime_ should be wrapped inside a `try/catch` (and once again not expose the exception message).

These decisions may change in a future major version if feedback suggest it's better to hide everything.