### PR TITLE
Fix password being visible as property of `UserInformation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- The password was still being visible inside the `Innmind\Url\Authority\UserInformation::$string` property. The property has been removed.
+
 ## 4.3.1 - 2024-10-19
 
 ### Changed

--- a/src/Authority/UserInformation.php
+++ b/src/Authority/UserInformation.php
@@ -18,6 +18,8 @@ final class UserInformation
 
     private function __construct(User $user, Password $password)
     {
+        // Make sure a user is specified when a password is specified
+        $password->format($user);
         $this->user = $user;
         $this->password = $password;
     }

--- a/src/Authority/UserInformation.php
+++ b/src/Authority/UserInformation.php
@@ -15,13 +15,11 @@ final class UserInformation
 {
     private User $user;
     private Password $password;
-    private string $string;
 
     private function __construct(User $user, Password $password)
     {
         $this->user = $user;
         $this->password = $password;
-        $this->string = $password->format($user);
     }
 
     /**
@@ -86,6 +84,6 @@ final class UserInformation
 
     public function toString(): string
     {
-        return $this->string;
+        return $this->password->format($this->user);
     }
 }


### PR DESCRIPTION
## Problem

The PR #2 removed the possibility to view the password when dumping the objects to avoid accidental exposure.

The password is still being visible inside the `UserInformation::$string` property.

## Solution

Compute the value when accessed instead of pre-computing it at construct time.