### PR TITLE
Add `Url::resolve()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Innmind\Url\Url::resolve()`
+
+### Fixed
+
+- Urls made only of relative paths were improperly parsed
+
 ## 5.1.0 - 2026-01-24
 
 ### Changed

--- a/src/Authority/Host.php
+++ b/src/Authority/Host.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Innmind\Url\Authority;
 
+use Innmind\Url\Url;
 use Uri\WhatWg\Url as Concrete;
 use Uri\Rfc3986\Uri;
 
@@ -22,13 +23,9 @@ final class Host
     public static function of(string $value): self
     {
         try {
-            /** @psalm-suppress ImpureMethodCall */
-            $url = new Concrete('http://a.org');
-            /** @psalm-suppress ImpureMethodCall */
-            $url = $url->withHost($value);
-
-            /** @psalm-suppress ImpureMethodCall */
-            return new self($value);
+            return Url::of('http://'.$value)
+                ->authority()
+                ->host();
         } catch (\Exception) {
             throw new \DomainException($value);
         }

--- a/src/Authority/Host.php
+++ b/src/Authority/Host.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Innmind\Url\Authority;
 
 use Uri\WhatWg\Url as Concrete;
+use Uri\Rfc3986\Uri;
 
 /**
  * @psalm-immutable
@@ -40,6 +41,21 @@ final class Host
     public static function none(): self
     {
         return new self('');
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function parsed(Uri $parsed): self
+    {
+        /** @psalm-suppress ImpureMethodCall */
+        $host = $parsed->getRawHost();
+
+        return match ($host) {
+            null => self::none(),
+            default => new self($host),
+        };
     }
 
     #[\NoDiscard]

--- a/src/Authority/Host.php
+++ b/src/Authority/Host.php
@@ -58,6 +58,32 @@ final class Host
         };
     }
 
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function parsedUrl(
+        Concrete $parsed,
+        #[\SensitiveParameter] string $origin,
+    ): self {
+        /** @psalm-suppress ImpureMethodCall */
+        $host = $parsed->getUnicodeHost();
+
+        if (!\is_null($host) && !\str_contains($origin, $host)) {
+            /** @psalm-suppress ImpureMethodCall */
+            $host = $parsed->getAsciiHost();
+        }
+
+        if ($host === 'a.org' && !\str_contains($origin, 'a.org')) {
+            return self::none();
+        }
+
+        return match ($host) {
+            null => self::none(),
+            default => new self($host),
+        };
+    }
+
     #[\NoDiscard]
     public function equals(self $host): bool
     {

--- a/src/Authority/Port.php
+++ b/src/Authority/Port.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Innmind\Url\Authority;
 
+use Uri\WhatWg\Url as Concrete;
 use Uri\Rfc3986\Uri;
 
 /**
@@ -40,7 +41,7 @@ final class Port
      * @internal
      * @psalm-pure
      */
-    public static function parsed(Uri $parsed): self
+    public static function parsed(Uri|Concrete $parsed): self
     {
         /** @psalm-suppress ImpureMethodCall */
         $port = $parsed->getPort();

--- a/src/Authority/Port.php
+++ b/src/Authority/Port.php
@@ -3,6 +3,8 @@ declare(strict_types = 1);
 
 namespace Innmind\Url\Authority;
 
+use Uri\Rfc3986\Uri;
+
 /**
  * @psalm-immutable
  */
@@ -32,6 +34,21 @@ final class Port
     public static function none(): self
     {
         return new self(null);
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function parsed(Uri $parsed): self
+    {
+        /** @psalm-suppress ImpureMethodCall */
+        $port = $parsed->getPort();
+
+        return match ($port) {
+            null => self::none(),
+            default => new self($port),
+        };
     }
 
     #[\NoDiscard]

--- a/src/Authority/UserInformation/Password.php
+++ b/src/Authority/UserInformation/Password.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Innmind\Url\Authority\UserInformation;
 
 use Uri\WhatWg\Url as Concrete;
+use Uri\Rfc3986\Uri;
 
 /**
  * @psalm-immutable
@@ -44,6 +45,21 @@ final class Password
     public static function none(): self
     {
         return new self('');
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function parsed(Uri $parsed): self
+    {
+        /** @psalm-suppress ImpureMethodCall */
+        $password = $parsed->getPassword();
+
+        return match ($password) {
+            null => self::none(),
+            default => new self($password),
+        };
     }
 
     #[\NoDiscard]

--- a/src/Authority/UserInformation/Password.php
+++ b/src/Authority/UserInformation/Password.php
@@ -51,7 +51,7 @@ final class Password
      * @internal
      * @psalm-pure
      */
-    public static function parsed(Uri $parsed): self
+    public static function parsed(Uri|Concrete $parsed): self
     {
         /** @psalm-suppress ImpureMethodCall */
         $password = $parsed->getPassword();

--- a/src/Authority/UserInformation/Password.php
+++ b/src/Authority/UserInformation/Password.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Innmind\Url\Authority\UserInformation;
 
+use Innmind\Url\Url;
 use Uri\WhatWg\Url as Concrete;
 use Uri\Rfc3986\Uri;
 
@@ -26,13 +27,13 @@ final class Password
     public static function of(#[\SensitiveParameter] string $value): self
     {
         try {
-            /** @psalm-suppress ImpureMethodCall */
-            $url = new Concrete('http://a.org');
-            /** @psalm-suppress ImpureMethodCall */
-            $url = $url->withPassword($value);
-
-            /** @psalm-suppress ImpureMethodCall */
-            return new self((string) $url->getPassword());
+            return Url::of(\sprintf(
+                'http://u:%s@a.org',
+                $value,
+            ))
+                ->authority()
+                ->userInformation()
+                ->password();
         } catch (\Exception) {
             throw new \DomainException($value);
         }

--- a/src/Authority/UserInformation/User.php
+++ b/src/Authority/UserInformation/User.php
@@ -3,7 +3,10 @@ declare(strict_types = 1);
 
 namespace Innmind\Url\Authority\UserInformation;
 
-use Innmind\Url\Authority\Host;
+use Innmind\Url\{
+    Url,
+    Authority\Host,
+};
 use Uri\WhatWg\Url as Concrete;
 use Uri\Rfc3986\Uri;
 
@@ -23,13 +26,13 @@ final class User
     public static function of(string $value): self
     {
         try {
-            /** @psalm-suppress ImpureMethodCall */
-            $url = new Concrete('http://a.org');
-            /** @psalm-suppress ImpureMethodCall */
-            $url = $url->withUsername($value);
-
-            /** @psalm-suppress ImpureMethodCall */
-            return new self((string) $url->getUsername());
+            return Url::of(\sprintf(
+                'http://%s@a.org',
+                $value,
+            ))
+                ->authority()
+                ->userInformation()
+                ->user();
         } catch (\Exception) {
             throw new \DomainException($value);
         }

--- a/src/Authority/UserInformation/User.php
+++ b/src/Authority/UserInformation/User.php
@@ -5,6 +5,7 @@ namespace Innmind\Url\Authority\UserInformation;
 
 use Innmind\Url\Authority\Host;
 use Uri\WhatWg\Url as Concrete;
+use Uri\Rfc3986\Uri;
 
 /**
  * @psalm-immutable
@@ -41,6 +42,21 @@ final class User
     public static function none(): self
     {
         return new self('');
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function parsed(Uri $parsed): self
+    {
+        /** @psalm-suppress ImpureMethodCall */
+        $user = $parsed->getUsername();
+
+        return match ($user) {
+            null => self::none(),
+            default => new self($user),
+        };
     }
 
     #[\NoDiscard]

--- a/src/Authority/UserInformation/User.php
+++ b/src/Authority/UserInformation/User.php
@@ -48,7 +48,7 @@ final class User
      * @internal
      * @psalm-pure
      */
-    public static function parsed(Uri $parsed): self
+    public static function parsed(Uri|Concrete $parsed): self
     {
         /** @psalm-suppress ImpureMethodCall */
         $user = $parsed->getUsername();

--- a/src/Fragment.php
+++ b/src/Fragment.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Innmind\Url;
 
 use Uri\WhatWg\Url as Concrete;
+use Uri\Rfc3986\Uri;
 
 /**
  * @psalm-immutable
@@ -40,6 +41,21 @@ final class Fragment
     public static function none(): self
     {
         return new self('');
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function parsed(Uri $parsed): self
+    {
+        /** @psalm-suppress ImpureMethodCall */
+        $fragment = $parsed->getFragment();
+
+        return match ($fragment) {
+            null => self::none(),
+            default => new self($fragment),
+        };
     }
 
     #[\NoDiscard]

--- a/src/Fragment.php
+++ b/src/Fragment.php
@@ -22,13 +22,7 @@ final class Fragment
     public static function of(string $value): self
     {
         try {
-            /** @psalm-suppress ImpureMethodCall */
-            $url = new Concrete('http://a.org');
-            /** @psalm-suppress ImpureMethodCall */
-            $url = $url->withFragment($value);
-
-            /** @psalm-suppress ImpureMethodCall */
-            return new self((string) $url->getFragment());
+            return Url::of('http://a.org/#'.$value)->fragment();
         } catch (\Exception) {
             throw new \DomainException($value);
         }

--- a/src/Fragment.php
+++ b/src/Fragment.php
@@ -47,7 +47,7 @@ final class Fragment
      * @internal
      * @psalm-pure
      */
-    public static function parsed(Uri $parsed): self
+    public static function parsed(Uri|Concrete $parsed): self
     {
         /** @psalm-suppress ImpureMethodCall */
         $fragment = $parsed->getFragment();

--- a/src/Path.php
+++ b/src/Path.php
@@ -26,15 +26,16 @@ abstract class Path
         }
 
         try {
-            /** @psalm-suppress ImpureMethodCall */
-            $url = new Concrete('http://a.org/');
-            /** @psalm-suppress ImpureMethodCall */
-            $url = $url->withPath($value);
-
-            return $value[0] === '/' ? new AbsolutePath($value) : new RelativePath($value);
+            $path = Url::of($value)->path();
         } catch (\Exception) {
             throw new \DomainException($value);
         }
+
+        if ($path instanceof RelativePath) {
+            return new RelativePath($value);
+        }
+
+        return new AbsolutePath($value);
     }
 
     /**

--- a/src/Path.php
+++ b/src/Path.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Innmind\Url;
 
 use Uri\WhatWg\Url as Concrete;
+use Uri\Rfc3986\Uri;
 
 /**
  * @psalm-immutable
@@ -43,6 +44,26 @@ abstract class Path
     final public static function none(): self
     {
         return new AbsolutePath('');
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    final public static function parsed(Uri $parsed): self
+    {
+        /** @psalm-suppress ImpureMethodCall */
+        $path = $parsed->getRawPath();
+
+        if ($path === '') {
+            return self::none();
+        }
+
+        if ($path[0] === '/') {
+            return new AbsolutePath($path);
+        }
+
+        return new RelativePath($path);
     }
 
     #[\NoDiscard]

--- a/src/Path.php
+++ b/src/Path.php
@@ -71,6 +71,20 @@ abstract class Path
         return new RelativePath($path);
     }
 
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    final public static function initiallyRelative(self $self): self
+    {
+        $path = \substr($self->toString(), 1);
+
+        return match ($path) {
+            '' => self::none(),
+            default => new RelativePath($path),
+        };
+    }
+
     #[\NoDiscard]
     final public function equals(self $path): bool
     {

--- a/src/Path.php
+++ b/src/Path.php
@@ -50,10 +50,15 @@ abstract class Path
      * @internal
      * @psalm-pure
      */
-    final public static function parsed(Uri $parsed): self
+    final public static function parsed(Uri|Concrete $parsed): self
     {
-        /** @psalm-suppress ImpureMethodCall */
-        $path = $parsed->getRawPath();
+        if ($parsed instanceof Uri) {
+            /** @psalm-suppress ImpureMethodCall */
+            $path = $parsed->getRawPath();
+        } else {
+            /** @psalm-suppress ImpureMethodCall */
+            $path = $parsed->getPath();
+        }
 
         if ($path === '') {
             return self::none();

--- a/src/Query.php
+++ b/src/Query.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Innmind\Url;
 
 use Uri\WhatWg\Url as Concrete;
+use Uri\Rfc3986\Uri;
 
 /**
  * @psalm-immutable
@@ -40,6 +41,21 @@ final class Query
     public static function none(): self
     {
         return new self('');
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function parsed(Uri $parsed): self
+    {
+        /** @psalm-suppress ImpureMethodCall */
+        $query = $parsed->getQuery();
+
+        return match ($query) {
+            null => self::none(),
+            default => new self($query),
+        };
     }
 
     #[\NoDiscard]

--- a/src/Query.php
+++ b/src/Query.php
@@ -22,13 +22,7 @@ final class Query
     public static function of(string $value): self
     {
         try {
-            /** @psalm-suppress ImpureMethodCall */
-            $url = new Concrete('http://a.org');
-            /** @psalm-suppress ImpureMethodCall */
-            $url = $url->withQuery($value);
-
-            /** @psalm-suppress ImpureMethodCall */
-            return new self((string) $url->getQuery());
+            return Url::of('http://a.org/?'.$value)->query();
         } catch (\Exception) {
             throw new \DomainException($value);
         }

--- a/src/Query.php
+++ b/src/Query.php
@@ -47,7 +47,7 @@ final class Query
      * @internal
      * @psalm-pure
      */
-    public static function parsed(Uri $parsed): self
+    public static function parsed(Uri|Concrete $parsed): self
     {
         /** @psalm-suppress ImpureMethodCall */
         $query = $parsed->getQuery();

--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -21,14 +21,12 @@ final class Scheme
     #[\NoDiscard]
     public static function of(string $value): self
     {
-        try {
-            /** @psalm-suppress ImpureMethodCall */
-            $url = new Uri('http://a.org');
-            /** @psalm-suppress ImpureMethodCall */
-            $url = $url->withScheme($value);
+        if (\str_ends_with($value, '://')) {
+            throw new \DomainException($value);
+        }
 
-            /** @psalm-suppress ImpureMethodCall */
-            return new self((string) $url->getScheme());
+        try {
+            return Url::of($value.'://a.org/')->scheme();
         } catch (\Exception) {
             throw new \DomainException($value);
         }

--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -3,7 +3,8 @@ declare(strict_types = 1);
 
 namespace Innmind\Url;
 
-use Uri\Rfc3986\Uri as Concrete;
+use Uri\WhatWg\Url as Concrete;
+use Uri\Rfc3986\Uri;
 
 /**
  * @psalm-immutable
@@ -22,7 +23,7 @@ final class Scheme
     {
         try {
             /** @psalm-suppress ImpureMethodCall */
-            $url = new Concrete('http://a.org');
+            $url = new Uri('http://a.org');
             /** @psalm-suppress ImpureMethodCall */
             $url = $url->withScheme($value);
 
@@ -37,7 +38,7 @@ final class Scheme
      * @internal
      * @psalm-pure
      */
-    public static function parsed(Concrete $parsed): self
+    public static function parsed(Uri $parsed): self
     {
         /** @psalm-suppress ImpureMethodCall */
         $scheme = $parsed->getScheme();
@@ -46,6 +47,27 @@ final class Scheme
             null => self::none(),
             default => new self($scheme),
         };
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function parsedUrl(
+        Concrete $parsed,
+        #[\SensitiveParameter] string $origin,
+    ): self {
+        /** @psalm-suppress ImpureMethodCall */
+        $scheme = $parsed->getScheme();
+
+        if (
+            $scheme === 'http' &&
+            !\str_starts_with($origin, 'http://')
+        ) {
+            return self::none();
+        }
+
+        return new self($scheme);
     }
 
     /**

--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -34,6 +34,21 @@ final class Scheme
     }
 
     /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function parsed(Concrete $parsed): self
+    {
+        /** @psalm-suppress ImpureMethodCall */
+        $scheme = $parsed->getScheme();
+
+        return match ($scheme) {
+            null => self::none(),
+            default => new self($scheme),
+        };
+    }
+
+    /**
      * @psalm-pure
      */
     #[\NoDiscard]

--- a/src/Url.php
+++ b/src/Url.php
@@ -13,6 +13,7 @@ use Innmind\Url\{
 use Innmind\Immutable\{
     Maybe,
     Attempt,
+    Str,
 };
 use Uri\WhatWg\Url as _Url;
 use Uri\Rfc3986\Uri;
@@ -270,10 +271,125 @@ final class Url
         );
     }
 
+    /**
+     * @return Attempt<self>
+     */
+    #[\NoDiscard]
+    public function resolve(self $destination): Attempt
+    {
+        return match ($this->parsed) {
+            null => Attempt::result($this->manualResolve($destination)),
+            default => $this->nativeResolve($this->parsed, $destination),
+        };
+    }
+
     #[\NoDiscard]
     public function toString(): string
     {
         return $this->scheme->format($this->authority).$this->path->format($this->query, $this->fragment);
+    }
+
+    private function manualResolve(self $destination): self
+    {
+        if (!$destination->authority()->equals(Authority::none())) {
+            return $destination;
+        }
+
+        if (
+            !$destination->path()->equals(Path::none()) &&
+            $destination->path()->absolute()
+        ) {
+            return $this
+                ->withPath($destination->path())
+                ->withQuery($destination->query())
+                ->withFragment($destination->fragment());
+        }
+
+        if (
+            $destination->path()->equals(Path::none()) &&
+            !$destination->query()->equals(Query::none())
+        ) {
+            return $this
+                ->withQuery($destination->query())
+                ->withFragment($destination->fragment());
+        }
+
+        if (
+            $destination->path()->equals(Path::none()) &&
+            !$destination->fragment()->equals(Fragment::none())
+        ) {
+            return $this->withFragment($destination->fragment());
+        }
+
+        $destinationPath = Str::of($destination->path()->toString());
+        $originPath = $this->path;
+
+        if (!$originPath->directory()) {
+            $originPath = $this->up($originPath);
+        }
+
+        if ($destinationPath->startsWith('./')) {
+            $destinationPath = $destinationPath->substring(2);
+        }
+
+        if ($destinationPath->startsWith('../')) {
+            $destinationPath = $destinationPath->substring(3);
+            $originPath = $this->up($originPath);
+        }
+
+        if ($destinationPath->empty()) {
+            return $this
+                ->withPath($originPath)
+                ->withQuery($destination->query())
+                ->withFragment($destination->fragment());
+        }
+
+        return $this
+            ->withPath($originPath->resolve(Path::of($destinationPath->toString())))
+            ->withQuery($destination->query())
+            ->withFragment($destination->fragment());
+    }
+
+    /**
+     * @return Attempt<self>
+     */
+    private function nativeResolve(
+        _Url|Uri $parsed,
+        self $destination,
+    ): Attempt {
+        try {
+            $uri = $destination->toString();
+
+            if (
+                !$destination->authority()->equals(Authority::none()) &&
+                $destination->scheme()->equals(Scheme::none())
+            ) {
+                $uri = '//'.$uri;
+            }
+
+            /** @psalm-suppress ImpureMethodCall */
+            $url = $parsed->resolve($uri);
+
+            if ($url instanceof Uri) {
+                /** @psalm-suppress ImpureMethodCall */
+                $url = $url->toRawString();
+            } else {
+                /** @psalm-suppress ImpureMethodCall */
+                $url = $url->toUnicodeString();
+            }
+
+            return self::attempt($url);
+        } catch (\Throwable $e) {
+            return Attempt::result(self::manualResolve($destination));
+        }
+    }
+
+    private function up(Path $path): Path
+    {
+        $path = $path->toString();
+        $up = \dirname($path);
+
+        return Path::of(\rtrim($up, '/').'/');
     }
 
     /**

--- a/src/Url.php
+++ b/src/Url.php
@@ -28,6 +28,7 @@ final class Url
         private Path $path,
         private Query $query,
         private Fragment $fragment,
+        private _Url|Uri|null $parsed,
     ) {
     }
 
@@ -48,6 +49,7 @@ final class Url
             $path,
             $query,
             $fragment,
+            null,
         );
     }
 
@@ -123,6 +125,7 @@ final class Url
             $this->path,
             $this->query,
             $this->fragment,
+            null,
         );
     }
 
@@ -135,6 +138,7 @@ final class Url
             $this->path,
             $this->query,
             $this->fragment,
+            null,
         );
     }
 
@@ -153,6 +157,7 @@ final class Url
             $this->path,
             $this->query,
             $this->fragment,
+            null,
         );
     }
 
@@ -165,6 +170,7 @@ final class Url
             $this->path,
             $this->query,
             $this->fragment,
+            null,
         );
     }
 
@@ -183,6 +189,7 @@ final class Url
             $path,
             $this->query,
             $this->fragment,
+            null,
         );
     }
 
@@ -195,6 +202,7 @@ final class Url
             Path::none(),
             $this->query,
             $this->fragment,
+            null,
         );
     }
 
@@ -213,6 +221,7 @@ final class Url
             $this->path,
             $query,
             $this->fragment,
+            null,
         );
     }
 
@@ -225,6 +234,7 @@ final class Url
             $this->path,
             Query::none(),
             $this->fragment,
+            null,
         );
     }
 
@@ -243,6 +253,7 @@ final class Url
             $this->path,
             $this->query,
             $fragment,
+            null,
         );
     }
 
@@ -255,6 +266,7 @@ final class Url
             $this->path,
             $this->query,
             Fragment::none(),
+            null,
         );
     }
 
@@ -289,6 +301,7 @@ final class Url
             Path::parsed($uri),
             Query::parsed($uri),
             Fragment::parsed($uri),
+            $uri,
         );
     }
 
@@ -351,12 +364,13 @@ final class Url
             $path = Path::initiallyRelative($path);
         }
 
-        return self::from(
+        return new self(
             $scheme,
             $authority,
             $path,
             $query,
             $fragment,
+            $url,
         );
     }
 }

--- a/src/Url.php
+++ b/src/Url.php
@@ -15,6 +15,7 @@ use Innmind\Immutable\{
     Attempt,
 };
 use Uri\WhatWg\Url as _Url;
+use Uri\Rfc3986\Uri;
 
 /**
  * @psalm-immutable
@@ -56,6 +57,12 @@ final class Url
     #[\NoDiscard]
     public static function of(#[\SensitiveParameter] string $string): self
     {
+        $self = self::tryUri($string);
+
+        if (!\is_null($self)) {
+            return $self;
+        }
+
         try {
             return self::tryUrl($string);
         } catch (\Exception $e) {
@@ -255,6 +262,34 @@ final class Url
     public function toString(): string
     {
         return $this->scheme->format($this->authority).$this->path->format($this->query, $this->fragment);
+    }
+
+    /**
+     * @psalm-pure
+     * @psalm-suppress ImpureMethodCall
+     */
+    private static function tryUri(#[\SensitiveParameter] string $string): ?self
+    {
+        $uri = Uri::parse($string);
+
+        if (\is_null($uri)) {
+            return null;
+        }
+
+        return new self(
+            Scheme::parsed($uri),
+            Authority::of(
+                UserInformation::of(
+                    User::parsed($uri),
+                    Password::parsed($uri),
+                ),
+                Host::parsed($uri),
+                Port::parsed($uri),
+            ),
+            Path::parsed($uri),
+            Query::parsed($uri),
+            Fragment::parsed($uri),
+        );
     }
 
     /**

--- a/src/Url.php
+++ b/src/Url.php
@@ -348,11 +348,7 @@ final class Url
             $authority->equals(Authority::none()) &&
             !\str_starts_with($string, '/')
         ) {
-            $path = \substr($path->toString(), 1);
-            $path = match ($path) {
-                '' => Path::none(),
-                default => Path::of($path),
-            };
+            $path = Path::initiallyRelative($path);
         }
 
         return self::from(

--- a/src/Url.php
+++ b/src/Url.php
@@ -300,85 +300,37 @@ final class Url
     {
         $string = \trim($string);
         $url = new _Url($string, new _Url('http://a.org'));
-        $scheme = $url->getScheme();
-        $user = $url->getUsername();
-        $password = $url->getPassword();
-        $host = $url->getUnicodeHost();
-        $port = $url->getPort();
-        $path = $url->getPath();
-        $query = $url->getQuery();
-        $fragment = $url->getFragment();
+        $scheme = Scheme::parsedUrl($url, $string);
+        $user = User::parsed($url);
+        $password = Password::parsed($url);
+        $host = Host::parsedUrl($url, $string);
+        $port = Port::parsed($url);
+        $path = Path::parsed($url);
+        $query = Query::parsed($url);
+        $fragment = Fragment::parsed($url);
 
-        if (!\is_null($host) && !\str_contains($string, $host)) {
-            $host = $url->getAsciiHost();
-        }
+        if ($host->toString() === 'a.org' && \str_contains($string, 'a.org')) {
+            $start = self::from(
+                $scheme,
+                Authority::of(
+                    UserInformation::of($user, $password),
+                    $host,
+                    $port,
+                ),
+                Path::none(),
+                Query::none(),
+                Fragment::none(),
+            );
+            $withScheme = $start->toString();
+            $schemeLess = '//'.$start
+                ->withoutScheme()
+                ->toString();
 
-        if (
-            $scheme === 'http' &&
-            !\str_starts_with($string, 'http://')
-        ) {
-            $scheme = null;
-        }
-
-        $scheme = match ($scheme) {
-            null => Scheme::none(),
-            default => Scheme::of($scheme),
-        };
-        $user = match ($user) {
-            null => User::none(),
-            default => User::of($user),
-        };
-        $password = match ($password) {
-            null => Password::none(),
-            default => Password::of($password),
-        };
-        $host = match ($host) {
-            null, '' => Host::none(),
-            default => Host::of($host),
-        };
-        $port = match ($port) {
-            null => Port::none(),
-            default => Port::of($port),
-        };
-        $path = match ($path) {
-            '' => Path::none(),
-            default => Path::of($path),
-        };
-        $query = match ($query) {
-            null => Query::none(),
-            default => Query::of($query),
-        };
-        $fragment = match ($fragment) {
-            null => Fragment::none(),
-            default => Fragment::of($fragment),
-        };
-
-        if ($host->toString() === 'a.org') {
-            if (!\str_contains($string, 'a.org')) {
+            if (
+                !\str_starts_with($string, $withScheme) &&
+                !\str_starts_with($string, $schemeLess)
+            ) {
                 $host = Host::none();
-            } else {
-                $start = self::from(
-                    $scheme,
-                    Authority::of(
-                        UserInformation::of($user, $password),
-                        $host,
-                        $port,
-                    ),
-                    Path::none(),
-                    Query::none(),
-                    Fragment::none(),
-                );
-                $withScheme = $start->toString();
-                $schemeLess = '//'.$start
-                    ->withoutScheme()
-                    ->toString();
-
-                if (
-                    !\str_starts_with($string, $withScheme) &&
-                    !\str_starts_with($string, $schemeLess)
-                ) {
-                    $host = Host::none();
-                }
             }
         }
 

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -293,6 +293,15 @@ class UrlTest extends TestCase
             });
     }
 
+    #[DataProvider('normalized')]
+    public function testParsedUrlIsNotAltered($url)
+    {
+        $this->assertSame(
+            $url,
+            Url::of($url)->toString(),
+        );
+    }
+
     public static function cases(): array
     {
         return [
@@ -367,6 +376,104 @@ class UrlTest extends TestCase
         ];
     }
 
+    public static function normalized(): array
+    {
+        return [
+            ['/wiki/Category:42'],
+            ['/wiki/Category:42?some=query'],
+            ['http://a.pl/'],
+            ['http://www.google.com/'],
+            ['http://www.google.museum/'],
+            ['https://google.com/'],
+            ['http://www.example.coop/'],
+            ['http://www.test-example.com/'],
+            ['http://www.symfony.com/'],
+            ['http://symfony.fake/blog/'],
+            ['http://symfony.com/'],
+            ['http://symfony.com/search?type=&q=url+validator'],
+            ['http://www.symfony.com/doc/current/book/validation.html#supported-constraints'],
+            ['http://very.long.domain.name.com/'],
+            ['http://localhost/'],
+            ['http://myhost123/'],
+            ['http://127.0.0.1/'],
+            ['http://127.0.0.1/'],
+            ['http://[::1]/'],
+            ['http://[::1]/'],
+            ['http://[1:2:3:0:4:5:6:7]/'],
+            ['http://sãopaulo.com/'],
+            ['http://xn--sopaulo-xwa.com/'],
+            ['http://sãopaulo.com.br/'],
+            ['http://xn--sopaulo-xwa.com.br/'],
+            ['http://пример.испытание/'],
+            ['http://xn--e1afmkfd.xn--80akhbyknj4f/'],
+            ['http://مثال.إختبار/'],
+            ['http://xn--mgbh0fb.xn--kgbechtv/'],
+            ['http://例子.测试/'],
+            ['http://xn--fsqu00a.xn--0zwm56d/'],
+            ['http://例子.測試/'],
+            ['http://xn--fsqu00a.xn--g6w251d/'],
+            ['http://例え.テスト/'],
+            ['http://xn--r8jz45g.xn--zckzah/'],
+            ['http://مثال.آزمایشی/'],
+            ['http://xn--mgbh0fb.xn--hgbk6aj7f53bba/'],
+            ['http://실례.테스트/'],
+            ['http://xn--9n2bp8q.xn--9t4b11yi5a/'],
+            ['http://العربية.idn.icann.org/'],
+            ['http://xn--ogb.idn.icann.org/'],
+            ['http://xn--e1afmkfd.xn--80akhbyknj4f.xn--e1afmkfd/'],
+            ['http://xn--espaa-rta.xn--ca-ol-fsay5a/'],
+            ['http://xn--d1abbgf6aiiy.xn--p1ai/'],
+            ['http://☎.com/'],
+            ['http://username:password@symfony.com/'],
+            ['http://user-name@symfony.com/'],
+            ['http://symfony.com/'],
+            ['http://symfony.com/?query=1'],
+            ['http://symfony.com/#fragment'],
+            ['http://www.independent.co.uk/service/privacy-policy-a6184181.html'],
+            ['http://del.icio.us/post?url=http://news.bbc.co.uk/2/hi/entertainment/7619828.stm&amp;title=New%20Hitchhiker%27s%20author%20announced'],
+            ['example.com'],
+            ['http://example.com/'],
+            ['http://example.com/bar'],
+            ['http://xn--example.com/foo/baz'],
+            ['http://xn--example.com/foo/baz/'],
+            ['http://xn--example.com/foo/'],
+            ['http://xn--example.com:80/foo/'],
+            ['https://xn--example.com:443/foo/'],
+            ['http://xn-elsewhere.com/'],
+            ['/path/to/content'],
+            ['/path/to/content?query=foo#fragment'],
+            ['/path/to/content/'],
+            ['/foo/baz'],
+            ['foo'],
+            ['./bar'],
+            ['bar'],
+            ['bar/baz?query=string#fragment'],
+            ['?query=string'],
+            ['#fragment'],
+            ['/absolute'],
+            ['../'],
+            ['xn--example.com/'],
+            ['../bar'],
+            ['../bar/foo'],
+            ['http://example.com/foo'],
+            ['http://xn--example.com/foo/bar'],
+            ['http://xn--example.com/foo/bar/baz?query=string#fragment'],
+            ['http://xn--example.com/bar/foo'],
+            ['http://xn--example.com/foo/baz?query=string'],
+            ['http://xn--example.com/foo/baz/?query=string'],
+            ['http://xn--example.com/foo/baz/#fragment'],
+            ['http://xn--example.com/foo/baz#fragment'],
+            ['http://xn--example.com/absolute'],
+            ['http://xn--example.com:80/'],
+            ['https://xn--example.com:443/'],
+            ['http://xn--example.com/'],
+            ['/path/bar'],
+            ['/path/to/bar'],
+            ['/path/to/content/bar'],
+            ['/bar/foo'],
+        ];
+    }
+
     public static function fromString(): array
     {
         return [
@@ -386,9 +493,9 @@ class UrlTest extends TestCase
             ['http://symfony.com/search?type=&q=url+validator', 'http', '', '', 'symfony.com', '', '/search', 'type=&q=url+validator', ''],
             ['http://symfony.com/#', 'http', '', '', 'symfony.com', '', '/', '', ''],
             ['http://symfony.com/#?', 'http', '', '', 'symfony.com', '', '/', '', '?'],
-            ['http://127.0.0.1:80/', 'http', '', '', '127.0.0.1', '', '/', '', ''],
-            ['http://[::1]:80/', 'http', '', '', '[::1]', '', '/', '', ''],
-            ['http://[1:2:3::4:5:6:7]/', 'http', '', '', '[1:2:3:0:4:5:6:7]', '', '/', '', ''],
+            ['http://127.0.0.1:80/', 'http', '', '', '127.0.0.1', '80', '/', '', ''],
+            ['http://[::1]:80/', 'http', '', '', '[::1]', '80', '/', '', ''],
+            ['http://[1:2:3::4:5:6:7]/', 'http', '', '', '[1:2:3::4:5:6:7]', '', '/', '', ''],
             ['http://sãopaulo.com/', 'http', '', '', 'sãopaulo.com', '', '/', '', ''],
             ['http://xn--sopaulo-xwa.com/', 'http', '', '', 'xn--sopaulo-xwa.com', '', '/', '', ''],
             ['http://пример.испытание/', 'http', '', '', 'пример.испытание', '', '/', '', ''],

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -302,6 +302,18 @@ class UrlTest extends TestCase
         );
     }
 
+    #[DataProvider('resolvable')]
+    public function testResolve(string $source, string $destination, string $expected)
+    {
+        $this->assertSame(
+            $expected,
+            Url::of($source)
+                ->resolve(Url::of($destination))
+                ->unwrap()
+                ->toString(),
+        );
+    }
+
     public static function cases(): array
     {
         return [
@@ -597,6 +609,37 @@ class UrlTest extends TestCase
                 'with=query',
                 'and-fragment',
             ],
+        ];
+    }
+
+    public static function resolvable(): array
+    {
+        return [
+            ['//example.com', 'foo', 'example.com/foo'],
+            ['http://example.com', 'foo', 'http://example.com/foo'],
+            ['http://example.com/bar', 'http://example.com/foo', 'http://example.com/foo'],
+            ['http://xn--example.com/foo/baz', './bar', 'http://xn--example.com/foo/bar'],
+            ['http://xn--example.com/foo/baz', 'bar', 'http://xn--example.com/foo/bar'],
+            ['http://xn--example.com/foo/baz', 'bar/baz?query=string#fragment', 'http://xn--example.com/foo/bar/baz?query=string#fragment'],
+            ['http://xn--example.com/foo/baz', '../bar/foo', 'http://xn--example.com/bar/foo'],
+            ['http://xn--example.com/foo/baz', '?query=string', 'http://xn--example.com/foo/baz?query=string'],
+            ['http://xn--example.com/foo/baz/', '?query=string', 'http://xn--example.com/foo/baz/?query=string'],
+            ['http://xn--example.com/foo/baz/', '#fragment', 'http://xn--example.com/foo/baz/#fragment'],
+            ['http://xn--example.com/foo/baz', '#fragment', 'http://xn--example.com/foo/baz#fragment'],
+            ['http://xn--example.com/foo/baz', '/absolute', 'http://xn--example.com/absolute'],
+            ['http://xn--example.com/foo/', '/absolute', 'http://xn--example.com/absolute'],
+            ['http://xn--example.com:80/foo/', '../', 'http://xn--example.com:80/'],
+            ['https://xn--example.com:443/foo/', '../', 'https://xn--example.com:443/'],
+            ['http://xn-elsewhere.com/', '//xn--example.com/', 'http://xn--example.com/'],
+            ['/path/to/content', '../bar', '/path/bar'],
+            ['/path/to/content', './bar', '/path/to/bar'],
+            ['/path/to/content', 'bar', '/path/to/bar'],
+            ['/path/to/content?query=foo#fragment', 'bar', '/path/to/bar'],
+            ['/path/to/content/', '../bar', '/path/to/bar'],
+            ['/path/to/content/', './bar', '/path/to/content/bar'],
+            ['/path/to/content/', 'bar', '/path/to/content/bar'],
+            ['/path/to/content/?query=foo#fragment', 'bar', '/path/to/content/bar'],
+            ['/foo/baz', '../bar/foo', '/bar/foo'],
         ];
     }
 }


### PR DESCRIPTION
This new method replaces the package `innmind/url-resolver` and fixes parsing relative paths.

It now tries both native `Url` and `Uri` strategies to support parsing relative paths.

Each public constructor now relies on the root `Url` parsing to always try both strategies. Then each component is internally built by giving it the native parsed `Url`/`Uri`.

As for `Url::resolve()` it tries the native resolving when there's still a reference to the parsed `Url`/`Uri`. Otherwise it does the resolving manually (the implementation is the `innmind/url-resolver` one).