### PR TITLE
Add `Scheme::less()` to avoid parsing idempotency issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `Innmind\Url\Scheme::less()`
 
+### Changed
+
+- _Scheme less_ urls now keep their leading `//` when converted to strings
+
 ## 5.3.0 - 2026-05-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Innmind\Url\Scheme::less()`
+
 ## 5.3.0 - 2026-05-14
 
 ### Changed

--- a/fixtures/Path.php
+++ b/fixtures/Path.php
@@ -34,6 +34,7 @@ final class Path
         return Set::strings()
             ->filter(static fn($value) => (bool) \preg_match('~\S+~', $value))
             ->exclude(static fn($value) => \str_contains($value, '//'))
-            ->exclude(static fn($value) => \str_starts_with($value, '\\'));
+            ->exclude(static fn($value) => \str_starts_with($value, '\\'))
+            ->map(static fn($value) => \trim($value, ' '));
     }
 }

--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -67,6 +67,13 @@ final class Scheme
 
         if (
             $scheme === 'http' &&
+            \str_starts_with($origin, '//')
+        ) {
+            return self::less();
+        }
+
+        if (
+            $scheme === 'http' &&
             !\str_starts_with($origin, 'http://')
         ) {
             return self::none();

--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -11,8 +11,10 @@ use Uri\Rfc3986\Uri;
  */
 final class Scheme
 {
-    private function __construct(private string $value)
-    {
+    private function __construct(
+        private string $value,
+        private bool $less = false,
+    ) {
     }
 
     /**
@@ -77,6 +79,17 @@ final class Scheme
         return new self('');
     }
 
+    /**
+     * This will force the url to start with '//' unlike `::none()`
+     *
+     * @psalm-pure
+     */
+    #[\NoDiscard]
+    public static function less(): self
+    {
+        return new self('', true);
+    }
+
     #[\NoDiscard]
     public function equals(self $scheme): bool
     {
@@ -86,6 +99,10 @@ final class Scheme
     #[\NoDiscard]
     public function format(Authority $authority): string
     {
+        if ($this->less) {
+            return '//'.$authority->toString();
+        }
+
         if ($this->value === '') {
             return $authority->toString();
         }

--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -38,13 +38,18 @@ final class Scheme
      * @internal
      * @psalm-pure
      */
-    public static function parsed(Uri $parsed): self
-    {
+    public static function parsed(
+        Uri $parsed,
+        #[\SensitiveParameter] string $origin,
+    ): self {
         /** @psalm-suppress ImpureMethodCall */
         $scheme = $parsed->getScheme();
 
         return match ($scheme) {
-            null => self::none(),
+            null => match (\str_starts_with($origin, '//')) {
+                true => self::less(),
+                false => self::none(),
+            },
             default => new self($scheme),
         };
     }
@@ -93,7 +98,8 @@ final class Scheme
     #[\NoDiscard]
     public function equals(self $scheme): bool
     {
-        return $this->value === $scheme->value;
+        return $this->value === $scheme->value &&
+            $this->less === $scheme->less;
     }
 
     #[\NoDiscard]

--- a/src/Url.php
+++ b/src/Url.php
@@ -405,7 +405,7 @@ final class Url
         }
 
         return new self(
-            Scheme::parsed($uri),
+            Scheme::parsed($uri, $string),
             Authority::of(
                 UserInformation::of(
                     User::parsed($uri),

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -317,6 +317,20 @@ class UrlTest extends TestCase
         );
     }
 
+    public function testSchemeLessUrls(): BlackBox\Proof
+    {
+        return $this
+            ->forAll(Fixture::any())
+            ->prove(function($url) {
+                $this->assertStringStartsWith(
+                    '//',
+                    $url
+                        ->withScheme(Scheme::less())
+                        ->toString(),
+                );
+            });
+    }
+
     public static function cases(): array
     {
         return [

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -268,7 +268,7 @@ class UrlTest extends TestCase
     {
         $url = Url::of('//example.com');
 
-        $this->assertSame('example.com/', $url->toString());
+        $this->assertSame('//example.com/', $url->toString());
     }
 
     public function testPathIsAbsolute()
@@ -632,7 +632,7 @@ class UrlTest extends TestCase
     public static function resolvable(): array
     {
         return [
-            ['//example.com', 'foo', 'example.com/foo'],
+            ['//example.com', 'foo', '//example.com/foo'],
             ['http://example.com', 'foo', 'http://example.com/foo'],
             ['http://example.com/bar', 'http://example.com/foo', 'http://example.com/foo'],
             ['http://xn--example.com/foo/baz', './bar', 'http://xn--example.com/foo/bar'],

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -88,6 +88,14 @@ class UrlTest extends TestCase
         $this->assertSame($fragment, $url->fragment()->toString());
     }
 
+    public function testParseSchemeLessUrl()
+    {
+        $this->assertSame(
+            '//مثال.إختبار/',
+            Url::of('//مثال.إختبار/')->toString(),
+        );
+    }
+
     #[DataProvider('fromString')]
     #[DataProvider('parseable')]
     public function testValidStringsReturnAnUrl($string)
@@ -626,6 +634,7 @@ class UrlTest extends TestCase
                 'with=query',
                 'and-fragment',
             ],
+            ['//مثال.إختبار/', '', '', '', 'مثال.إختبار', '', '/', '', ''],
         ];
     }
 


### PR DESCRIPTION
Fix #17 