### PR TITLE
Improve fixtures

### DIFF
--- a/fixtures/Authority.php
+++ b/fixtures/Authority.php
@@ -24,6 +24,10 @@ final class Authority
                 Authority\Port::any(),
                 Set::of(Model\Port::none()),
             ),
-        );
+        )
+            ->exclude(
+                static fn($authority) => !$authority->userInformation()->equals(Model\UserInformation::none()) &&
+                    $authority->host()->equals(Model\Host::none()),
+            );
     }
 }

--- a/fixtures/Path.php
+++ b/fixtures/Path.php
@@ -13,7 +13,32 @@ final class Path
      */
     public static function any(): Set
     {
-        return self::strings()->map(Model::of(...));
+        return Set::either(
+            self::relative(),
+            self::absolute(),
+        );
+    }
+
+    /**
+     * @return Set<Model>
+     */
+    public static function relative(): Set
+    {
+        return self::strings()
+            ->map(static fn($value) => \ltrim($value, '/'))
+            ->exclude(static fn($value) => \str_ends_with($value, '\\'))
+            ->map(Model::of(...));
+    }
+
+    /**
+     * @return Set<Model>
+     */
+    public static function absolute(): Set
+    {
+        return self::strings()
+            ->map(static fn($value) => '/'.\ltrim($value, '/'))
+            ->exclude(static fn($value) => \str_ends_with($value, '\\'))
+            ->map(Model::of(...));
     }
 
     /**

--- a/fixtures/Path.php
+++ b/fixtures/Path.php
@@ -71,6 +71,7 @@ final class Path
             )
             ->filter(static fn($value) => (bool) \preg_match('~\S+~', $value))
             ->exclude(static fn($value) => \str_contains($value, '//'))
+            ->exclude(static fn($value) => \str_contains($value, '\\@'))
             ->exclude(static fn($value) => \str_starts_with($value, '\\'))
             ->map(static fn($value) => \trim($value, ' '));
     }

--- a/fixtures/Path.php
+++ b/fixtures/Path.php
@@ -3,7 +3,10 @@ declare(strict_types = 1);
 
 namespace Fixtures\Innmind\Url;
 
-use Innmind\Url\Path as Model;
+use Innmind\Url\{
+    Path as Model,
+    Url,
+};
 use Innmind\BlackBox\Set;
 
 final class Path
@@ -73,6 +76,11 @@ final class Path
             ->exclude(static fn($value) => \str_contains($value, '//'))
             ->exclude(static fn($value) => \str_contains($value, '\\@'))
             ->exclude(static fn($value) => \str_starts_with($value, '\\'))
-            ->map(static fn($value) => \trim($value, ' '));
+            ->map(static fn($value) => \trim($value, ' '))
+            ->exclude(static fn($value) => $value === '')
+            ->filter(static fn($value) => Url::attempt($value)->match(
+                static fn() => true,
+                static fn() => false,
+            ));
     }
 }

--- a/fixtures/Url.php
+++ b/fixtures/Url.php
@@ -5,6 +5,7 @@ namespace Fixtures\Innmind\Url;
 
 use Innmind\Url\{
     Url as Model,
+    Scheme as SchemeModel,
     Authority as AuthorityModel,
     Path as PathModel,
     Query as QueryModel,
@@ -19,15 +20,21 @@ final class Url
      */
     public static function any(): Set
     {
-        return Set::compose(
+        $url = Set::compose(
             Model::from(...),
-            Scheme::any(),
+            Set::either(
+                Scheme::any(),
+                Set::of(
+                    SchemeModel::none(),
+                    SchemeModel::less(),
+                ),
+            ),
             Set::either(
                 Authority::any(),
                 Set::of(AuthorityModel::none()),
             ),
             Set::either(
-                Path::any(),
+                Path::absolute(),
                 Set::of(PathModel::none()),
             ),
             Set::either(
@@ -38,6 +45,54 @@ final class Url
                 Fragment::any(),
                 Set::of(FragmentModel::none()),
             ),
+        )
+            ->exclude(
+                static fn($url) => !$url->authority()->port()->equals(AuthorityModel\Port::none()) && (
+                    $url->authority()->host()->equals(AuthorityModel\Host::none()) ||
+                    $url->scheme()->equals(SchemeModel::none())
+                ),
+            )
+            ->exclude(
+                static fn($url) => !$url->query()->equals(QueryModel::none()) &&
+                    $url->path()->equals(PathModel::none()),
+            )
+            ->exclude(
+                static fn($url) => !$url->fragment()->equals(FragmentModel::none()) &&
+                    $url->path()->equals(PathModel::none()),
+            )
+            ->exclude(
+                static fn($url) => $url->scheme()->equals(SchemeModel::less()) &&
+                    $url->authority()->equals(AuthorityModel::none()),
+            )
+            ->exclude(
+                static fn($url) => $url->authority()->equals(AuthorityModel::none()) && !(
+                    $url->scheme()->equals(SchemeModel::none()) ||
+                    $url->scheme()->equals(SchemeModel::less())
+                ),
+            )
+            ->exclude(
+                static fn($url) => !$url->scheme()->equals(SchemeModel::none()) &&
+                    $url->authority()->port()->value() > 65535,
+            );
+        $path = Path::relative()->map(
+            static fn($path) => Model::from(
+                SchemeModel::none(),
+                AuthorityModel::none(),
+                $path,
+                QueryModel::none(),
+                FragmentModel::none(),
+            ),
         );
+        $file = Path::absolute()->map(
+            static fn($path) => Model::from(
+                SchemeModel::of('file'),
+                AuthorityModel::none(),
+                $path,
+                QueryModel::none(),
+                FragmentModel::none(),
+            ),
+        );
+
+        return Set::either($url, $path, $file);
     }
 }

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -347,6 +347,17 @@ class UrlTest extends TestCase
         );
     }
 
+    public function testAnyUrlFixtureCanBeParsed(): BlackBox\Proof
+    {
+        return $this
+            ->forAll(Fixture::any())
+            ->prove(function($url) {
+                $this->assert()->not()->throws(
+                    static fn() => Url::of($url->toString()),
+                );
+            });
+    }
+
     public static function cases(): array
     {
         return [

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -358,6 +358,17 @@ class UrlTest extends TestCase
             });
     }
 
+    public function testAnyUrlsCanBeResolved(): BlackBox\Proof
+    {
+        return $this
+            ->forAll(Fixture::any(), Fixture::any())
+            ->prove(function($a, $b) {
+                $this->assert()->not()->throws(
+                    static fn() => $a->resolve($b)->unwrap(),
+                );
+            });
+    }
+
     public static function cases(): array
     {
         return [


### PR DESCRIPTION
Fix #21 

Unlike described in the issue, this PR doesn't add an equality check as the generation of non encoded values is done on purpose and the parsing encode these values (so the equality fails as it's a strict comparison).